### PR TITLE
Add compatibility with Django 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ calls for your django-rest-framework code. It does this by inspecting your seria
 they use, and what models they refer to, and automatically calculating what needs to be prefetched.
 
 ## Installation
-`pip install django_auto_prefetching`
+`pip install django-auto-prefetching`
 
 ## AutoPrefetchViewSetMixin
 This is a ViewSet mixin you can use, which will automatically prefetch the needed objects from the database.

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,11 @@ DESCRIPTION = "Tools for automatically prefetching related objects in Django and
 URL = "https://github.com/GeeWee/django-auto-prefetching"
 EMAIL = "gustavwengel@gmail.com"
 AUTHOR = "Gustav Wengel"
-REQUIRES_PYTHON = ">=3.7.0"
+REQUIRES_PYTHON = ">=3.6.9"
 VERSION = "0.1.7"
 
 # What packages are required for this module to be executed?
-REQUIRED = ["django ~= 2.2"]
+REQUIRED = ["django >= 2.2"]
 
 # What packages are optional?
 EXTRAS = {"Rest framework integration": ["djangorestframework ~= 3.9"]}


### PR DESCRIPTION
- Allow this package to be installed on Django 3.0 and Python 3.6.9.
  - Tested with Django 3.0 and Python 3.6.9, all test cases pass.
- Change `django_auto_prefetching` to `django-auto-prefetching` in the readme to match what [PyPi](https://pypi.org/project/django-auto-prefetching/) recommends.