### PR TITLE
Don't require specific patch release of Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ DESCRIPTION = "Tools for automatically prefetching related objects in Django and
 URL = "https://github.com/GeeWee/django-auto-prefetching"
 EMAIL = "gustavwengel@gmail.com"
 AUTHOR = "Gustav Wengel"
-REQUIRES_PYTHON = ">=3.6.9"
+REQUIRES_PYTHON = ">=3.6"
 VERSION = "0.1.8"
 
 # What packages are required for this module to be executed?


### PR DESCRIPTION
Generally, patch release versions shouldn't be enforced in `setup.py` unless there is a specific bug that is necessary to be fixed in a patch release.

This doesn't seem to be the case for this project, this this should make the next release more flexible to install for users.