### PR TITLE
Updated documentation for how to override get_queryset manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ It supports all types of relational fields, (many to many, one to many, one to o
 ### Limitations
 The `AutoPrefetchViewSetMixin` cannot see what objects are being accessed in e.g. a `SerializerMethodField`.
 If you use objects in there, you might need to do some additional prefetches.
+If you do this and override `get_queryset`, you will have to call `prefetch` manually as the mixin code is never reached.
 
 ```python
-from django_auto_prefetching import AutoPrefetchViewSetMixin
+import django_auto_prefetching
 from rest_framework.viewsets import ModelViewSet
 
-class BaseModelViewSet(AutoPrefetchViewSetMixin, ModelViewSet):
+class BaseModelViewSet(django_auto_prefetching.AutoPrefetchViewSetMixin, ModelViewSet):
     serializer_class = YourModelSerializer
     
     def get_queryset(self):
@@ -42,7 +43,7 @@ class BaseModelViewSet(AutoPrefetchViewSetMixin, ModelViewSet):
             # and leave the mixin to do the rest of the work
             queryset = YourModel.objects.all()
             queryset = queryset.select_related('my_extra_field')
-            return queryset
+            return django_auto_prefetching.prefetch(queryset, self.serializer_class)
 
 ```
 

--- a/test_project/serializers/child_a_serializer.py
+++ b/test_project/serializers/child_a_serializer.py
@@ -19,7 +19,6 @@ class ChildABrotherSerializerWithBrother(ModelSerializer):
 
 
 class ChildASerializer(ModelSerializer):
-    # brother = ChildABrotherSerializer(read_only=True)
 
     class Meta:
         model = ChildA
@@ -28,7 +27,6 @@ class ChildASerializer(ModelSerializer):
 
 
 class ChildASerializerWithNoRelations(ModelSerializer):
-    # brother = ChildABrotherSerializer(read_only=True)
 
     class Meta:
         model = ChildA

--- a/test_project/tests/test_queryset_override.py
+++ b/test_project/tests/test_queryset_override.py
@@ -48,6 +48,7 @@ class GetQuerysetOverrideTest(TestCase):
             actions={"get": "list"}
         )
 
+        # Only 1 query as prefetch is called manually
         with self.assertNumQueries(1):
             data = view(self.factory.get("/")).data
             pprint_result(data)

--- a/test_project/tests/test_queryset_override.py
+++ b/test_project/tests/test_queryset_override.py
@@ -1,0 +1,62 @@
+import logging
+from json import loads, dumps
+from pprint import pprint
+
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+from rest_framework.utils.serializer_helpers import ReturnList
+
+from test_project.models import (
+    ChildA,
+)
+from test_project.views import WrongQuerySetOverride, RightQuerySetOverride
+
+logger = logging.getLogger("django-auto-prefetching")
+logger.setLevel(level=logging.DEBUG)
+
+
+class GetQuerysetOverrideTest(TestCase):
+    factory = APIRequestFactory()
+
+    def test_that_it_does_not_work_when_overriding_get_queryset_wrong(self):
+        """
+        This viewSet overrides the get_queryset method, so the mixin is never called
+        """
+        ChildA.objects.create(childA_text="text")
+        ChildA.objects.create(childA_text="text")
+
+        view = WrongQuerySetOverride.as_view(
+            actions={"get": "list"}
+        )
+
+        # 1 list query and 2 for siblings
+        with self.assertNumQueries(3):
+            data = view(self.factory.get("/")).data
+            pprint_result(data)
+            self.assertEqual(len(data), 2)
+
+    def test_that_it_does_work_when_overriding_get_queryset_right(self):
+        """
+        This viewSet overrides the get_queryset method but calls prefetch manually
+        """
+        ChildA.objects.create(childA_text="text")
+        ChildA.objects.create(childA_text="text")
+        ChildA.objects.create(childA_text="text")
+        ChildA.objects.create(childA_text="text")
+
+        view = RightQuerySetOverride.as_view(
+            actions={"get": "list"}
+        )
+
+        with self.assertNumQueries(1):
+            data = view(self.factory.get("/")).data
+            pprint_result(data)
+            self.assertEqual(len(data), 4)
+
+
+def pprint_result(list: ReturnList):
+    # Convert to regular dicts
+    def to_dict(input_ordered_dict):
+        return loads(dumps(input_ordered_dict))
+
+    pprint([to_dict(res) for res in list])

--- a/test_project/views.py
+++ b/test_project/views.py
@@ -2,11 +2,13 @@
 from rest_framework.viewsets import ModelViewSet
 
 from django_auto_prefetching import AutoPrefetchViewSetMixin
+import django_auto_prefetching
+from test_project.serializers.child_a_serializer import ChildASerializer
 from test_project.serializers.child_b_serializers import ChildBSerializer
 from test_project.serializers.many_to_many_serializer import (
     ManyTwoSerializerOnlyFullRepresentation,
 )
-from test_project.models import ManyToManyModelTwo, ChildB
+from test_project.models import ManyToManyModelTwo, ChildB, ChildA
 
 
 class ManyTwoSerializerOnlyFullRepresentationViewSet(
@@ -19,3 +21,18 @@ class ManyTwoSerializerOnlyFullRepresentationViewSet(
 class ChildBViewSet(ModelViewSet):
     serializer_class = ChildBSerializer
     queryset = ChildB.objects.all()
+
+
+class WrongQuerySetOverride(AutoPrefetchViewSetMixin, ModelViewSet):
+    serializer_class = ChildASerializer
+
+    def get_queryset(self):
+        return ChildA.objects.all()
+
+
+class RightQuerySetOverride(AutoPrefetchViewSetMixin, ModelViewSet):
+    serializer_class = ChildASerializer
+
+    def get_queryset(self):
+        qs = ChildA.objects.all()
+        return django_auto_prefetching.prefetch(qs, self.serializer_class)


### PR DESCRIPTION
The docs were incorrect before, telling you a wrong way to override `get_queryset` which meant the mixin code would never be called.

Fixes #21 