### PR TITLE
Add overridable method get_prefetchable_queryset to allow complex querysets

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ class BaseModelViewSet(django_auto_prefetching.AutoPrefetchViewSetMixin, ModelVi
         queryset = queryset.select_related('my_extra_field')
         return django_auto_prefetching.prefetch(queryset, self.serializer_class)
 ```
+You can override `get_prefetchable_queryset` instead of `get_queryset` if you don't want to manually call `django_auto_prefetching.prefetch()`. Example:
+```python
+import django_auto_prefetching
+from rest_framework.viewsets import ModelViewSet
+
+class BaseModelViewSet(django_auto_prefetching.AutoPrefetchViewSetMixin, ModelViewSet):
+    serializer_class = YourModelSerializer
+    
+    def get_prefetchable_queryset(self):
+        return YourModel.objects.all()
+```
+Now `get_queryset()` will call our `get_prefetchable_queryset()` and will add automatic prefetches
 
 ## Manually specifying which fields are needed
 

--- a/django_auto_prefetching/__init__.py
+++ b/django_auto_prefetching/__init__.py
@@ -42,9 +42,12 @@ class AutoPrefetchViewSetMixin:
     def get_auto_prefetch_extra_prefetch_fields(self):
         return self.auto_prefetch_extra_prefetch_fields
 
+    def get_prefetchable_queryset(self):
+        return super().get_queryset()
+
     def get_queryset(self):
         serializer = self.get_serializer()
-        qs = super().get_queryset()
+        qs = self.get_prefetchable_queryset()
 
         kwargs = {
             "excluded_fields": self.get_auto_prefetch_excluded_fields(),

--- a/test_project/tests/test_get_prefetchable_queryset_override.py
+++ b/test_project/tests/test_get_prefetchable_queryset_override.py
@@ -1,0 +1,36 @@
+import logging
+from json import loads, dumps
+from pprint import pprint
+
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+from rest_framework.utils.serializer_helpers import ReturnList
+
+from test_project.models import (
+    ChildA,
+)
+from test_project.views import GetPrefetchableQuerysetOverride, WrongQuerySetOverride, RightQuerySetOverride
+
+logger = logging.getLogger("django-auto-prefetching")
+logger.setLevel(level=logging.DEBUG)
+
+
+class GetQuerysetOverrideTest(TestCase):
+    factory = APIRequestFactory()
+
+    def test_that_get_prefetchable_queryset_is_not_called_when_overrides(self):
+        """
+        GetPrefetchableQuerysetOverride overrides the get_prefetchable_queryset method, so the mixin will call overrided get_prefetchable_queryset when get_queryset is called
+        """
+        ChildA.objects.create(childA_text="text_1")
+        ChildA.objects.create(childA_text="text_2")
+
+        view = GetPrefetchableQuerysetOverride.as_view(
+            actions={"get": "list"}
+        )
+
+        # Only 1 query because mixin get_queryset calls our overrided get_prefetchable_queryset.
+        # Our get_prefetchable_queryset filter by childA_text="text_1", so only 1 result
+        with self.assertNumQueries(1):
+            data = view(self.factory.get("/")).data
+            self.assertEqual(len(data), 1)

--- a/test_project/views.py
+++ b/test_project/views.py
@@ -36,3 +36,9 @@ class RightQuerySetOverride(AutoPrefetchViewSetMixin, ModelViewSet):
     def get_queryset(self):
         qs = ChildA.objects.all()
         return django_auto_prefetching.prefetch(qs, self.serializer_class)
+
+class GetPrefetchableQuerysetOverride(AutoPrefetchViewSetMixin, ModelViewSet):
+    serializer_class = ChildASerializer
+
+    def get_prefetchable_queryset(self):
+        return ChildA.objects.filter(childA_text='text_1')


### PR DESCRIPTION
This allows you to override `get_prefetchable_queryset` to create complex querysets. 

 Sometimes `queryset = Model.objects.all()` not enough and this is a very simple way to support complex querysets.

 If there is any trick to do this in a simple way I can remove this PR and use the suggested approach, but this seems like a clean way to me.

You can change the name of the overridable method if you don't like the one I suggested. 


Thanks, I'm waiting for news 
